### PR TITLE
feat(config): JpaConfig 추가 (#18)

### DIFF
--- a/src/main/java/com/opensource/weathercloset/WeatherclosetServerApplication.java
+++ b/src/main/java/com/opensource/weathercloset/WeatherclosetServerApplication.java
@@ -2,10 +2,8 @@ package com.opensource.weathercloset;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
-@EnableJpaAuditing
 public class WeatherclosetServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/opensource/weathercloset/common/config/JpaConfig.java
+++ b/src/main/java/com/opensource/weathercloset/common/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.opensource.weathercloset.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}


### PR DESCRIPTION
- DateTimeEntity의 createdAt, modifiedAt 처럼 DB에 데이터가 저장되거나 수정될 때 언제, 누가 했는지를 자동으로 관리하기 위해서 `@EnableJpaAuditing` 어노테이션을 필요로 합니다. 기존에는 `WeatherclosetServerApplication.java` 에 `@EnableJpaAuditing` 어노테이션을 넣었는데, 역할 분리 및 확장성 등을 고려하여 `JpaConfig.java` 에서 `@Configuration` `@EnableJpaAuditing` 로 변경하였습니다.


- DateTimeEntity와 관련된 내용들은 [벨로그](https://velog.io/@sians0209/Spring-%EC%83%9D%EC%84%B1%EC%8B%9C%EA%B0%84-%EC%88%98%EC%A0%95%EC%8B%9C%EA%B0%84-%EA%B4%80%EB%A6%AC)에 정리해 두었어요! 참고하시면 좋을 듯합니다 :)