### PR TITLE
fix: 수정/삭제 후 Response Body에 성공 메시지 남기기

### DIFF
--- a/src/main/java/com/opensource/weathercloset/common/dto/BasicResponse.java
+++ b/src/main/java/com/opensource/weathercloset/common/dto/BasicResponse.java
@@ -30,6 +30,11 @@ public class BasicResponse {
         return new ResponseEntity<>(basicResponse, HttpStatus.OK);
     }
 
+    public ResponseEntity<BasicResponse> noContent() {
+        BasicResponse basicResponse = new BasicResponse(204, "성공", "");
+        return new ResponseEntity<>(basicResponse, HttpStatus.OK);
+    }
+
     private BasicResponse(ErrorCode code, List<FieldError> errors) {
         this.status = code.getStatus();
         this.message = code.getMessage();

--- a/src/main/java/com/opensource/weathercloset/record/controller/CalendarController.java
+++ b/src/main/java/com/opensource/weathercloset/record/controller/CalendarController.java
@@ -23,7 +23,6 @@ public class CalendarController {
 
 
     @GetMapping("/{memberId}")
-    @ResponseStatus(OK)
     @Operation(summary = "캘린더(사용자 월 기록 조회)", description = "사용자의 월 기록을 조회합니다")
     public ResponseEntity<BasicResponse> getCalendarInfo(@PathVariable("memberId") Long memberId,
                                                          @RequestParam int year, @RequestParam int month) {

--- a/src/main/java/com/opensource/weathercloset/record/controller/RecordController.java
+++ b/src/main/java/com/opensource/weathercloset/record/controller/RecordController.java
@@ -23,7 +23,7 @@ import static org.springframework.http.HttpStatus.OK;
 public class RecordController {
 
     private final RecordService recordService;
-    private BasicResponse basicResponse = new BasicResponse();
+    private final BasicResponse basicResponse = new BasicResponse();
 
     @GetMapping("/member/{memberId}")
     @ResponseStatus(OK)
@@ -62,7 +62,7 @@ public class RecordController {
     @PutMapping("/record/{recordId}")
     @ResponseStatus(NO_CONTENT)
     @Operation(summary = "기록 수정", description = "이미지, 별점, 한 줄 기록, 좋아요 여부, 날짜를 수정합니다")
-    public ResponseEntity updateRecord(@PathVariable("recordId") Long recordId,
+    public ResponseEntity<BasicResponse> updateRecord(@PathVariable("recordId") Long recordId,
                                                       @RequestBody RecordUpdateRequestDTO requestDTO) {
         String imageUrl = requestDTO.getImageUrl();
         int stars = requestDTO.getStars();
@@ -71,26 +71,26 @@ public class RecordController {
         LocalDate recordDate = requestDTO.getRecordDate();
 
         recordService.updateRecord(imageUrl, recordId, stars, comment, heart, recordDate);
-        return ResponseEntity.noContent().build();
+        return basicResponse.noContent();
     }
 
     @PutMapping("/record/like/{recordId}")
     @ResponseStatus(NO_CONTENT)
     @Operation(summary = "좋아요 수정", description = "좋아요 여부를 수정합니다")
-    public ResponseEntity updateHeart(@PathVariable("recordId") Long recordId,
+    public ResponseEntity<BasicResponse> updateHeart(@PathVariable("recordId") Long recordId,
                                        @RequestBody HeartUpdateRequestDTO requestDTO) {
         boolean heart = requestDTO.isHeart();
 
         recordService.updateHeart(recordId, heart);
-        return ResponseEntity.noContent().build();
+        return basicResponse.noContent();
     }
 
     @DeleteMapping("/record/{recordId}")
     @ResponseStatus(NO_CONTENT)
     @Operation(summary = "기록 삭제", description = "기록을 삭제합니다")
-    public ResponseEntity deleteRecord(@PathVariable Long recordId) {
+    public ResponseEntity<BasicResponse> deleteRecord(@PathVariable Long recordId) {
         recordService.deleteRecord(recordId);
-        return ResponseEntity.noContent().build();
+        return basicResponse.noContent();
     }
 
 }

--- a/src/main/java/com/opensource/weathercloset/record/controller/RecordController.java
+++ b/src/main/java/com/opensource/weathercloset/record/controller/RecordController.java
@@ -26,7 +26,6 @@ public class RecordController {
     private final BasicResponse basicResponse = new BasicResponse();
 
     @GetMapping("/member/{memberId}")
-    @ResponseStatus(OK)
     @Operation(summary = "사용자 기록 조회", description = "사용자의 기록을 조회합니다")
     public ResponseEntity<BasicResponse> getRecords(@PathVariable("memberId") Long memberId) {
         return basicResponse.ok(
@@ -35,7 +34,6 @@ public class RecordController {
     }
 
     @GetMapping("/record/{recordId}")
-    @ResponseStatus(OK)
     @Operation(summary = "기록 단건 조회", description = "기록을 단건 조회합니다")
     public ResponseEntity<BasicResponse> getRecord(@PathVariable("recordId") Long recordId) {
         return basicResponse.ok(
@@ -44,7 +42,6 @@ public class RecordController {
     }
 
     @PostMapping("/record/{memberId}")
-    @ResponseStatus(OK)
     @Operation(summary = "기록 등록", description = "기록을 신규 등록합니다")
     public ResponseEntity<BasicResponse> addRecord(@PathVariable("memberId") Long memberId,
                                                    @RequestBody RecordRequestDTO requestDTO) {
@@ -60,7 +57,6 @@ public class RecordController {
     }
 
     @PutMapping("/record/{recordId}")
-    @ResponseStatus(NO_CONTENT)
     @Operation(summary = "기록 수정", description = "이미지, 별점, 한 줄 기록, 좋아요 여부, 날짜를 수정합니다")
     public ResponseEntity<BasicResponse> updateRecord(@PathVariable("recordId") Long recordId,
                                                       @RequestBody RecordUpdateRequestDTO requestDTO) {
@@ -75,7 +71,6 @@ public class RecordController {
     }
 
     @PutMapping("/record/like/{recordId}")
-    @ResponseStatus(NO_CONTENT)
     @Operation(summary = "좋아요 수정", description = "좋아요 여부를 수정합니다")
     public ResponseEntity<BasicResponse> updateHeart(@PathVariable("recordId") Long recordId,
                                        @RequestBody HeartUpdateRequestDTO requestDTO) {
@@ -86,7 +81,6 @@ public class RecordController {
     }
 
     @DeleteMapping("/record/{recordId}")
-    @ResponseStatus(NO_CONTENT)
     @Operation(summary = "기록 삭제", description = "기록을 삭제합니다")
     public ResponseEntity<BasicResponse> deleteRecord(@PathVariable Long recordId) {
         recordService.deleteRecord(recordId);

--- a/src/main/java/com/opensource/weathercloset/record/controller/RecordSearchController.java
+++ b/src/main/java/com/opensource/weathercloset/record/controller/RecordSearchController.java
@@ -20,7 +20,6 @@ public class RecordSearchController {
     private BasicResponse basicResponse = new BasicResponse();
 
     @GetMapping()
-    @ResponseStatus(OK)
     @Operation(summary = "기록 기온 범위 조회", description = "기온 범위에 해당하는 기록을 조회합니다")
     public ResponseEntity<BasicResponse> searchRecords (@RequestParam double minTemperature,
                                                         @RequestParam double maxTemperature) {

--- a/src/main/java/com/opensource/weathercloset/weather/controller/WeatherOpenAPI.java
+++ b/src/main/java/com/opensource/weathercloset/weather/controller/WeatherOpenAPI.java
@@ -47,7 +47,6 @@ public class WeatherOpenAPI {
 
     @Scheduled(cron="0 0 12 * * ?")
     @PostMapping("/api/parse")
-    @ResponseStatus(OK)
     @Operation(summary = "날씨 API 자동 호출", description = "매일 오후 12시에 전날의 날씨 정보를 호출하여 DB에 저장합니다")
     public ResponseEntity<Weather> addWeather() {
         try {


### PR DESCRIPTION
응답 코드를 [204](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204)로 할 경우 Response Body 를 담지 않습니다. 프론트엔드 측에서 기존에 만들어 둔 성공 응답 형태인 { "status" , "message", "data" } 형태로 응답 받길 요구하였고, 해당 요구사항에 따라 수정하였습니다.
다만 Response Body에 값을 담기 위해서는 응답 코드를 204(NO_CONTENT) 가 아닌 200(OK)로 변경해야 하는 문제점이 발생하였습니다. 따라서 날씨옷장의 모든 API는 성공 시 200(OK) 응답 코드를 가지게 되므로, 컨트롤러에서 `@ResponseStatus` 로 응답 형태를 미리 작성해야 할 필요성이 없으므로, 관련 어노테이션을 모두 삭제하였습니다.